### PR TITLE
added basic security Config. Needs more for authentication

### DIFF
--- a/src/main/java/com/cpr/codingparkrangers/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/cpr/codingparkrangers/configuration/SecurityConfiguration.java
@@ -1,0 +1,51 @@
+package com.cpr.codingparkrangers.configuration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+//
+//  @Autowired
+//  private BCryptPasswordEncoder bCryptPasswordEncoder;
+//
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception{
+    http
+            .authorizeRequests()
+            .antMatchers("/console/**").permitAll()
+            .antMatchers("/").permitAll()
+            .antMatchers("/login").permitAll()
+            .antMatchers("/signup").permitAll()
+            .anyRequest()
+            .authenticated().and().csrf().disable()
+            .formLogin()
+            .loginPage("/login").failureUrl("/login?error=true")
+            .defaultSuccessUrl("/")
+            .and()
+            .logout()
+            .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+            .logoutSuccessUrl("/login").and().exceptionHandling();
+  //            ALL TO BE ADDED AS WE CONTINUE.
+//            .antMatchers("/custom.js").permitAll()
+//            .antMatchers("/custom.css").permitAll()
+  }
+  @Override
+  public void configure(WebSecurity web) throws Exception{
+    web
+            .ignoring()
+            .antMatchers("/resources/**", "/static/**", "/css/**", "/js/**", "/images/**");
+  }
+
+}


### PR DESCRIPTION
Added basic config to obfuscate any endpoint that is not `/` , `/login` or `/signup` for unauthenticated users.

This requires a custom `login.html` and a custom `signup.html` to render for users.


